### PR TITLE
Fixed an issue copying the front-channel logout url.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.7.1
+
+- Fixed an issue copying the front-channel logout url.
+
 ## 0.7.0
 
 - Added commands to sign in and sign out of Azure CLI from the command palette.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "applicationregistrations",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "applicationregistrations",
-      "version": "0.7.0",
+      "version": "0.7.1",
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
         "@azure/identity": "^3.1.2",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   },
   "homepage": "https://github.com/irarainey/vscode-applicationregistrations/blob/main/README.md",
   "license": "SEE LICENSE IN LICENSE.md",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "engines": {
     "vscode": "^1.73.0"
   },

--- a/src/utils/copy-value.ts
+++ b/src/utils/copy-value.ts
@@ -9,6 +9,7 @@ export const copyValue = (item: AppRegItem) => {
             || item.contextValue === "SPA-REDIRECT-URI"
             || item.contextValue === "NATIVE-REDIRECT-URI"
             || item.contextValue === "APPID-URI"
+            || item.contextValue === "LOGOUT-URL"
             ? item.value!
             : item.children![0].value!);
 };


### PR DESCRIPTION
The copy function was not hooked up for the tree item type.