### PR TITLE
Include tenant ID in portal request URLs

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,25 +45,25 @@
           "default": 40,
           "minimum": 1,
           "maximum": 200,
-          "order": 1
+          "order": 0
         },
         "applicationRegistrations.showOwnedApplicationsOnly": {
           "type": "boolean",
           "description": "Show only applications owned by the current user.",
           "default": true,
-          "order": 2
+          "order": 1
         },
         "applicationRegistrations.useEventualConsistency": {
           "type": "boolean",
           "description": "Use the eventual consistency header on Graph API calls for generating the application list. Enable this if you are working with a large number of applications.",
           "default": true,
-          "order": 3
+          "order": 2
         },
         "applicationRegistrations.showApplicationCountWarning": {
           "type": "boolean",
           "description": "Displays a warning when loading the application list if it is detected that you could benefit from a change in the eventual consistency setting.",
           "default": true,
-          "order": 4
+          "order": 3
         },
         "applicationRegistrations.maximumQueryApps": {
           "type": "number",
@@ -71,19 +71,19 @@
           "default": 100,
           "minimum": 1,
           "maximum": 200,
-          "order": 5
+          "order": 4
         },
         "applicationRegistrations.includeEntraPortal": {
           "type": "boolean",
           "description": "Includes Open in Entra Portal alongside options to open applications or users in the Azure portal.",
           "default": true,
-          "order": 6
+          "order": 5
         },     
         "applicationRegistrations.omitTenantIdFromPortalRequests": {
           "type": "boolean",
           "description": "Disables the inclusion of tenant IDs in portal URLs when opening applications or users in the Azure and/or Entra portals. Including the tenant ID in the portal URLs can help when you have logged into the extension with a non-default tenant and try to open items in the portals.",
           "default": false,
-          "order": 7
+          "order": 6
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -39,39 +39,51 @@
     "configuration": {
       "title": "Azure Application Registrations",
       "properties": {
-        "applicationregistrations.maximumApplicationsShown": {
+        "applicationRegistrations.maximumApplicationsShown": {
           "type": "number",
           "description": "The maximum number of application registrations to be shown in the view.",
           "default": 40,
           "minimum": 1,
           "maximum": 200,
-          "order": 0
+          "order": 1
         },
-        "applicationregistrations.showOwnedApplicationsOnly": {
+        "applicationRegistrations.showOwnedApplicationsOnly": {
           "type": "boolean",
           "description": "Show only applications owned by the current user.",
           "default": true,
-          "order": 1
+          "order": 2
         },
-        "applicationregistrations.useEventualConsistency": {
+        "applicationRegistrations.useEventualConsistency": {
           "type": "boolean",
           "description": "Use the eventual consistency header on Graph API calls for generating the application list. Enable this if you are working with a large number of applications.",
           "default": true,
-          "order": 2
+          "order": 3
         },
-        "applicationregistrations.showApplicationCountWarning": {
+        "applicationRegistrations.showApplicationCountWarning": {
           "type": "boolean",
           "description": "Displays a warning when loading the application list if it is detected that you could benefit from a change in the eventual consistency setting.",
           "default": true,
-          "order": 3
+          "order": 4
         },
-        "applicationregistrations.maximumQueryApps": {
+        "applicationRegistrations.maximumQueryApps": {
           "type": "number",
           "description": "Maximum Graph API query size when not working with eventual consistency. Lower this number to improve performance when you don't have a large number of applications, but bear in mind that without eventual consistency Graph API results are not sorted so setting this below your total applications means you might not see all expected applications.",
           "default": 100,
           "minimum": 1,
           "maximum": 200,
-          "order": 4
+          "order": 5
+        },
+        "applicationRegistrations.includeEntraPortal": {
+          "type": "boolean",
+          "description": "Includes Open in Entra Portal alongside options to open applications or users in the Azure portal.",
+          "default": true,
+          "order": 6
+        },     
+        "applicationRegistrations.omitTenantIdFromPortalRequests": {
+          "type": "boolean",
+          "description": "Disables the inclusion of tenant IDs in portal URLs when opening applications or users in the Azure and/or Entra portals. Including the tenant ID in the portal URLs can help when you have logged into the extension with a non-default tenant and try to open items in the portals.",
+          "default": false,
+          "order": 7
         }
       }
     },
@@ -713,7 +725,7 @@
         },
         {
           "command": "appRegistrations.openAppInEntraPortal",
-          "when": "view == appRegistrations && viewItem == APPLICATION",
+          "when": "view == appRegistrations && viewItem == APPLICATION && config.applicationRegistrations.includeEntraPortal",
           "group": "appRegistrations@4"
         },        
         {
@@ -733,7 +745,7 @@
         },
         {
           "command": "appRegistrations.openUserInEntraPortal",
-          "when": "view == appRegistrations && viewItem == OWNER",
+          "when": "view == appRegistrations && viewItem == OWNER && config.applicationRegistrations.includeEntraPortal",
           "group": "appRegistrations@2"
         },        
         {

--- a/package.json
+++ b/package.json
@@ -241,6 +241,10 @@
         "title": "Open In Azure Portal"
       },
       {
+        "command": "appRegistrations.openAppInEntraPortal",
+        "title": "Open In Entra Portal"
+      },      
+      {
         "command": "appRegistrations.editAudience",
         "title": "Edit"
       },
@@ -252,6 +256,10 @@
         "command": "appRegistrations.openUserInAzurePortal",
         "title": "Open In Azure Portal"
       },
+      {
+        "command": "appRegistrations.openUserInEntraPortal",
+        "title": "Open In Entra Portal"
+      },      
       {
         "command": "appRegistrations.addOwner",
         "title": "Add"
@@ -492,6 +500,10 @@
           "when": "false"
         },
         {
+          "command": "appRegistrations.openAppInEntraPortal",
+          "when": "false"
+        },        
+        {
           "command": "appRegistrations.editAudience",
           "when": "false"
         },
@@ -503,6 +515,10 @@
           "command": "appRegistrations.openUserInAzurePortal",
           "when": "false"
         },
+        {
+          "command": "appRegistrations.openUserInEntraPortal",
+          "when": "false"
+        },        
         {
           "command": "appRegistrations.addOwner",
           "when": "false"
@@ -696,6 +712,11 @@
           "group": "appRegistrations@4"
         },
         {
+          "command": "appRegistrations.openAppInEntraPortal",
+          "when": "view == appRegistrations && viewItem == APPLICATION",
+          "group": "appRegistrations@4"
+        },        
+        {
           "command": "appRegistrations.addOwner",
           "when": "view == appRegistrations && viewItem == OWNERS",
           "group": "appRegistrations@0"
@@ -710,6 +731,11 @@
           "when": "view == appRegistrations && viewItem == OWNER",
           "group": "appRegistrations@2"
         },
+        {
+          "command": "appRegistrations.openUserInEntraPortal",
+          "when": "view == appRegistrations && viewItem == OWNER",
+          "group": "appRegistrations@2"
+        },        
         {
           "command": "appRegistrations.viewAppManifest",
           "when": "view == appRegistrations && viewItem == APPLICATION",

--- a/package.json
+++ b/package.json
@@ -237,8 +237,8 @@
         "title": "Copy Client ID"
       },
       {
-        "command": "appRegistrations.openAppInPortal",
-        "title": "Open In Portal"
+        "command": "appRegistrations.openAppInAzurePortal",
+        "title": "Open In Azure Portal"
       },
       {
         "command": "appRegistrations.editAudience",
@@ -249,8 +249,8 @@
         "title": "Copy"
       },
       {
-        "command": "appRegistrations.openUserInPortal",
-        "title": "Open In Portal"
+        "command": "appRegistrations.openUserInAzurePortal",
+        "title": "Open In Azure Portal"
       },
       {
         "command": "appRegistrations.addOwner",
@@ -488,7 +488,7 @@
           "when": "false"
         },
         {
-          "command": "appRegistrations.openAppInPortal",
+          "command": "appRegistrations.openAppInAzurePortal",
           "when": "false"
         },
         {
@@ -500,7 +500,7 @@
           "when": "false"
         },
         {
-          "command": "appRegistrations.openUserInPortal",
+          "command": "appRegistrations.openUserInAzurePortal",
           "when": "false"
         },
         {
@@ -691,7 +691,7 @@
           "group": "appRegistrations@3"
         },
         {
-          "command": "appRegistrations.openAppInPortal",
+          "command": "appRegistrations.openAppInAzurePortal",
           "when": "view == appRegistrations && viewItem == APPLICATION",
           "group": "appRegistrations@4"
         },
@@ -706,7 +706,7 @@
           "group": "appRegistrations@1"
         },
         {
-          "command": "appRegistrations.openUserInPortal",
+          "command": "appRegistrations.openUserInAzurePortal",
           "when": "view == appRegistrations && viewItem == OWNER",
           "group": "appRegistrations@2"
         },

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -8,13 +8,13 @@ export const SIGNIN_COMMAND_TEXT = "Sign in to Azure CLI";
 export const SCOPE = "https://graph.microsoft.com/.default";
 
 // URI Roots for the Azure Portal variations
-export const AZURE_PORTAL_APP_ROOT = "https://portal.azure.com";
-export const AZURE_PORTAL_APP_ROOT_USGOV = "https://portal.azure.us";
-export const AZURE_PORTAL_APP_ROOT_CHINA = "https://portal.azure.cn";
+export const AZURE_PORTAL_ROOT = "https://portal.azure.com";
+export const AZURE_PORTAL_ROOT_USGOV = "https://portal.azure.us";
+export const AZURE_PORTAL_ROOT_CHINA = "https://portal.azure.cn";
 // TODO - consider approach to take for Azure portal access in national clouds: https://learn.microsoft.com/graph/deployments#app-registration-and-token-service-root-endpoints
 
 // URI Roots for the Entra Portal variations
-export const ENTRA_PORTAL_APP_ROOT = "https://entra.microsoft.com";
+export const ENTRA_PORTAL_ROOT = "https://entra.microsoft.com";
 // TODO - determine (if available) Entra portal access in national clouds
 
 // The URI path to the Application Registration blade in the Azure & Entra Portals

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -11,15 +11,17 @@ export const SCOPE = "https://graph.microsoft.com/.default";
 export const AZURE_PORTAL_APP_ROOT = "https://portal.azure.com";
 export const AZURE_PORTAL_APP_ROOT_USGOV = "https://portal.azure.us";
 export const AZURE_PORTAL_APP_ROOT_CHINA = "https://portal.azure.cn";
-// TODO - consider approach to take for portal access in national clouds: https://learn.microsoft.com/graph/deployments#app-registration-and-token-service-root-endpoints
+// TODO - consider approach to take for Azure portal access in national clouds: https://learn.microsoft.com/graph/deployments#app-registration-and-token-service-root-endpoints
 
-// The URI path to the Application Registration blade in the Azure Portal
-export const AZURE_PORTAL_APP_PATH = "/#view/Microsoft_AAD_RegisteredApps/ApplicationMenuBlade/~/Overview/appId/";
-// export const PORTAL_APP_URI = "https://portal.azure.com/#view/Microsoft_AAD_RegisteredApps/ApplicationMenuBlade/~/Overview/appId/";
+// URI Roots for the Entra Portal variations
+export const ENTRA_PORTAL_APP_ROOT = "https://entra.microsoft.com";
+// TODO - determine (if available) Entra portal access in national clouds
 
-// The URI path to the User blade in the Azure Portal
-export const AZURE_PORTAL_USER_PATH = "/#view/Microsoft_AAD_UsersAndTenants/UserProfileMenuBlade/~/overview/userId/";
-// export const PORTAL_USER_URI = "https://portal.azure.com/#view/Microsoft_AAD_UsersAndTenants/UserProfileMenuBlade/~/overview/userId/";
+// The URI path to the Application Registration blade in the Azure & Entra Portals
+export const AZURE_AND_ENTRA_PORTAL_APP_PATH = "/#view/Microsoft_AAD_RegisteredApps/ApplicationMenuBlade/~/Overview/appId/";
+
+// The URI path to the User blade in the Azure & Entra Portals
+export const AZURE_AND_ENTRA_PORTAL_USER_PATH = "/#view/Microsoft_AAD_UsersAndTenants/UserProfileMenuBlade/~/overview/userId/";
 
 // The URI to access directory objects in the Microsoft Graph API
 export const DIRECTORY_OBJECTS_URI = "https://graph.microsoft.com/v1.0/directoryObjects/";

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -7,17 +7,32 @@ export const SIGNIN_COMMAND_TEXT = "Sign in to Azure CLI";
 // The scope required when authenticating with Azure CLI
 export const SCOPE = "https://graph.microsoft.com/.default";
 
-// The URI to the Application Registration blade in the Azure Portal
-export const PORTAL_APP_URI = "https://portal.azure.com/#view/Microsoft_AAD_RegisteredApps/ApplicationMenuBlade/~/Overview/appId/";
+// URI Roots for the Azure Portal variations
+export const AZURE_PORTAL_APP_ROOT = "https://portal.azure.com";
+export const AZURE_PORTAL_APP_ROOT_USGOV = "https://portal.azure.us";
+export const AZURE_PORTAL_APP_ROOT_CHINA = "https://portal.azure.cn";
+// TODO - consider approach to take for portal access in national clouds: https://learn.microsoft.com/graph/deployments#app-registration-and-token-service-root-endpoints
 
-// The URI to the User blade in the Azure Portal
-export const PORTAL_USER_URI = "https://portal.azure.com/#view/Microsoft_AAD_UsersAndTenants/UserProfileMenuBlade/~/overview/userId/";
+// The URI path to the Application Registration blade in the Azure Portal
+export const AZURE_PORTAL_APP_PATH = "/#view/Microsoft_AAD_RegisteredApps/ApplicationMenuBlade/~/Overview/appId/";
+// export const PORTAL_APP_URI = "https://portal.azure.com/#view/Microsoft_AAD_RegisteredApps/ApplicationMenuBlade/~/Overview/appId/";
+
+// The URI path to the User blade in the Azure Portal
+export const AZURE_PORTAL_USER_PATH = "/#view/Microsoft_AAD_UsersAndTenants/UserProfileMenuBlade/~/overview/userId/";
+// export const PORTAL_USER_URI = "https://portal.azure.com/#view/Microsoft_AAD_UsersAndTenants/UserProfileMenuBlade/~/overview/userId/";
 
 // The URI to access directory objects in the Microsoft Graph API
 export const DIRECTORY_OBJECTS_URI = "https://graph.microsoft.com/v1.0/directoryObjects/";
+export const DIRECTORY_OBJECTS_URI_USGOV = "https://graph.microsoft.us/v1.0/directoryObjects/";
+export const DIRECTORY_OBJECTS_URI_USGOV_DOD = "https://dod-graph.microsoft.us/v1.0/directoryObjects/";
+export const DIRECTORY_OBJECTS_URI_CHINA = "https://microsoftgraph.chinacloudapi.cn/v1.0/directoryObjects/";
+// TODO - consider approach to take for graph access in national clouds: https://learn.microsoft.com/graph/deployments#microsoft-graph-and-graph-explorer-service-root-endpoints
 
-// The base tenant endpoint
+// The base tenant endpoints
 export const BASE_ENDPOINT = "https://login.microsoftonline.com/";
+export const BASE_ENDPOINT_USGOV = "https://login.microsoftonline.us/";
+export const BASE_ENDPOINT_CHINA = "https://login.chinacloudapi.cn/";
+// TODO - consider approach to take for login in national clouds: https://learn.microsoft.com/graph/deployments#app-registration-and-token-service-root-endpoints
 
 // A list of properties to ignore when updating an application registration
 export const PROPERTIES_TO_IGNORE_ON_UPDATE = [
@@ -65,5 +80,11 @@ export const SIGNIN_AUDIENCE_DOCUMENTATION_URI = "https://learn.microsoft.com/en
 // The properties to return when querying for applications
 export const APPLICATION_SELECT_PROPERTIES = "id,displayName,appId,notes,signInAudience,appRoles,oauth2Permissions,web,spa,api,requiredResourceAccess,publicClient,identifierUris,passwordCredentials,keyCredentials";
 
-// The Azure CLI command to get the tenant id
-export const CLI_TENANT_CMD = "az account show --query tenantId -o tsv";
+// The Azure CLI command to login a user
+export const CLI_LOGIN_CMD = "az login";
+
+// The Azure CLI command to log out the current user
+export const CLI_LOGOUT_CMD = "az logout";
+
+// The Azure CLI command to get information about the current account
+export const CLI_ACCOUNT_INFO_CMD= "az account show -o json";

--- a/src/data/account-provider.ts
+++ b/src/data/account-provider.ts
@@ -1,0 +1,19 @@
+import { AccountInformation } from "../types/account-information";
+
+// Provides functionality related to the currently signed-in account
+export interface AccountProvider{
+    /**
+     * Log in a user to the indicated tenant (default tenant if blank)
+     */
+    loginUser(tenant: string): Promise<boolean>;
+
+    /**
+     * Log out the current user
+     */
+    logoutUser() : Promise<void>
+
+    /**
+     * Retrieve account information for the currently logged in user
+     */
+    getAccountInformation(): Promise<AccountInformation>;
+}

--- a/src/data/app-reg-tree-data-provider.ts
+++ b/src/data/app-reg-tree-data-provider.ts
@@ -146,7 +146,7 @@ export class AppRegTreeDataProvider implements TreeDataProvider<AppRegItem> {
 		}
 
 		// Determine if eventual consistency is enabled.
-		const useEventualConsistency = workspace.getConfiguration("applicationregistrations").get("useEventualConsistency") as boolean;
+		const useEventualConsistency = workspace.getConfiguration("applicationRegistrations").get("useEventualConsistency") as boolean;
 
 		// If eventual consistency is disabled then we cannot apply the filter
 		if (useEventualConsistency === false) {
@@ -303,13 +303,13 @@ export class AppRegTreeDataProvider implements TreeDataProvider<AppRegItem> {
 			this.isUpdating = true;
 
 			// Get the configuration settings.
-			const useEventualConsistency = workspace.getConfiguration("applicationregistrations").get("useEventualConsistency") as boolean;
-			const showApplicationCountWarning = workspace.getConfiguration("applicationregistrations").get("showApplicationCountWarning") as boolean;
+			const useEventualConsistency = workspace.getConfiguration("applicationRegistrations").get("useEventualConsistency") as boolean;
+			const showApplicationCountWarning = workspace.getConfiguration("applicationRegistrations").get("showApplicationCountWarning") as boolean;
 
 			// Determine if the warning message should be displayed.
 			if (showApplicationCountWarning === true) {
 				let totalApplicationCount: number = 0;
-				const showOwnedApplicationsOnly = workspace.getConfiguration("applicationregistrations").get("showOwnedApplicationsOnly") as boolean;
+				const showOwnedApplicationsOnly = workspace.getConfiguration("applicationRegistrations").get("showOwnedApplicationsOnly") as boolean;
 
 				// Get the total number of applications in the tenant based on the filter settings.
 				if (showOwnedApplicationsOnly) {
@@ -337,10 +337,10 @@ export class AppRegTreeDataProvider implements TreeDataProvider<AppRegItem> {
 					window.showWarningMessage(`You have enabled eventual consistency for Graph API calls but only have ${totalApplicationCount} applications in your tenant. You would likely benefit from disabling eventual consistency in user settings. Would you like to do this now?`, "Yes", "No", "Disable Warning").then((result) => {
 						// If the user selects "Disable Warning" then disable the warning message.
 						if (result === "Disable Warning") {
-							workspace.getConfiguration("applicationregistrations").update("showApplicationCountWarning", false, ConfigurationTarget.Global);
+							workspace.getConfiguration("applicationRegistrations").update("showApplicationCountWarning", false, ConfigurationTarget.Global);
 							// If the user selects "Yes" then disable eventual consistency.
 						} else if (result === "Yes") {
-							workspace.getConfiguration("applicationregistrations").update("useEventualConsistency", false, ConfigurationTarget.Global);
+							workspace.getConfiguration("applicationRegistrations").update("useEventualConsistency", false, ConfigurationTarget.Global);
 						}
 					});
 					// If the total number of applications is greater than 200 and eventual consistency is disabled then display a warning message.
@@ -348,10 +348,10 @@ export class AppRegTreeDataProvider implements TreeDataProvider<AppRegItem> {
 					window.showWarningMessage(`You do not have enabled eventual consistency enabled for Graph API calls and have ${totalApplicationCount} applications in your tenant. You would likely benefit from enabling eventual consistency in user settings. Would you like to do this now?`, "Yes", "No", "Disable Warning").then((result) => {
 						// If the user selects "Disable Warning" then disable the warning message.
 						if (result === "Disable Warning") {
-							workspace.getConfiguration("applicationregistrations").update("showApplicationCountWarning", false, ConfigurationTarget.Global);
+							workspace.getConfiguration("applicationRegistrations").update("showApplicationCountWarning", false, ConfigurationTarget.Global);
 							// If the user selects "Yes" then enable eventual consistency.
 						} else if (result === "Yes") {
-							workspace.getConfiguration("applicationregistrations").update("useEventualConsistency", true, ConfigurationTarget.Global);
+							workspace.getConfiguration("applicationRegistrations").update("useEventualConsistency", true, ConfigurationTarget.Global);
 						}
 					});
 				}
@@ -690,7 +690,7 @@ export class AppRegTreeDataProvider implements TreeDataProvider<AppRegItem> {
 	// Returns application list depending on the user setting
 	private async getApplicationList(): Promise<Application[] | undefined> {
 		// Get the user setting to determine whether to show all applications or just the ones owned by the user
-		const showOwnedApplicationsOnly = workspace.getConfiguration("applicationregistrations").get("showOwnedApplicationsOnly") as boolean;
+		const showOwnedApplicationsOnly = workspace.getConfiguration("applicationRegistrations").get("showOwnedApplicationsOnly") as boolean;
 		if (showOwnedApplicationsOnly === true) {
 			const result: GraphResult<Application[]> = await this.graphRepository.getApplicationListOwned(this.filterCommand);
 			if (result.success === true && result.value !== undefined) {

--- a/src/data/azure-cli-account-provider.ts
+++ b/src/data/azure-cli-account-provider.ts
@@ -1,0 +1,38 @@
+import { AccountProvider } from "./account-provider";
+import { AccountInformation } from "../types/account-information";
+import { execShellCmd } from "../utils/exec-shell-cmd";
+import { CLI_LOGIN_CMD, CLI_LOGOUT_CMD, CLI_ACCOUNT_INFO_CMD } from "../constants";
+
+// Provides functionality from the Azure CLI related to the currently signed-in account
+export class AzureCliAccountProvider implements AccountProvider{
+    async loginUser(tenant: string): Promise<boolean> {
+        // Build the command to invoke the Azure CLI sign-in command.
+	    let command = CLI_LOGIN_CMD;
+	    if (tenant.length > 0) {
+		    command += ` --tenant ${tenant}`;
+	    }
+
+	    // Execute the command.
+	    const status = await execShellCmd(command)
+		    .then(() => {
+			    return true;
+		    })
+		    .catch(() => {
+			    return false;
+		    });
+        return status;
+    }
+
+    async logoutUser(): Promise<void> {
+        // Invokes the Azure CLI sign-out command to sign the user out.
+	    await execShellCmd(CLI_LOGOUT_CMD);
+        return;
+    }
+
+    async getAccountInformation(): Promise<AccountInformation> {
+        // Execute the Azure CLI command to get the information about the current account (including tenant ID and cloud type)
+        const accountJsonText = await execShellCmd(CLI_ACCOUNT_INFO_CMD);
+        const accountInformation = new AccountInformation().deserialize(accountJsonText);
+        return accountInformation;
+    }
+}

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -42,7 +42,7 @@ const signInAudienceService = new SignInAudienceService(graphRepository, treeDat
 export async function activate(context: ExtensionContext) {
 	// Hook up the configuration setting change handlers.
 	workspace.onDidChangeConfiguration(async (event) => {
-		if (event.affectsConfiguration("applicationregistrations.showOwnedApplicationsOnly") || event.affectsConfiguration("applicationregistrations.maximumQueryApps") || event.affectsConfiguration("applicationregistrations.maximumApplicationsShown") || event.affectsConfiguration("applicationregistrations.useEventualConsistency")) {
+		if (event.affectsConfiguration("applicationRegistrations.showOwnedApplicationsOnly") || event.affectsConfiguration("applicationRegistrations.maximumQueryApps") || event.affectsConfiguration("applicationRegistrations.maximumApplicationsShown") || event.affectsConfiguration("applicationRegistrations.useEventualConsistency")) {
 			await treeDataProvider.render(setStatusBarMessage("Refreshing Application Registrations..."));
 		}
 	});

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -68,6 +68,7 @@ export async function activate(context: ExtensionContext) {
 	context.subscriptions.push(commands.registerCommand(`${VIEW_NAME}.copyClientId`, (item) => applicationService.copyClientId(item)));
 	context.subscriptions.push(commands.registerCommand(`${VIEW_NAME}.showEndpoints`, (item) => applicationService.showEndpoints(item)));
 	context.subscriptions.push(commands.registerCommand(`${VIEW_NAME}.openAppInAzurePortal`, async (item) => await applicationService.openInAzurePortal(item)));
+	context.subscriptions.push(commands.registerCommand(`${VIEW_NAME}.openAppInEntraPortal`, async (item) => await applicationService.openInEntraPortal(item)));
 
 	// App Role Commands
 	context.subscriptions.push(commands.registerCommand(`${VIEW_NAME}.addAppRole`, async (item) => await appRoleService.add(item)));
@@ -125,6 +126,7 @@ export async function activate(context: ExtensionContext) {
 	context.subscriptions.push(commands.registerCommand(`${VIEW_NAME}.addOwner`, async (item) => await ownerService.add(item)));
 	context.subscriptions.push(commands.registerCommand(`${VIEW_NAME}.removeOwner`, async (item) => await ownerService.remove(item)));
 	context.subscriptions.push(commands.registerCommand(`${VIEW_NAME}.openUserInAzurePortal`, async (item) => await ownerService.openInAzurePortal(item)));
+	context.subscriptions.push(commands.registerCommand(`${VIEW_NAME}.openUserInEntraPortal`, async (item) => await ownerService.openInEntraPortal(item)));
 
 	// Common Commands
 	context.subscriptions.push(commands.registerCommand(`${VIEW_NAME}.copyValue`, (item) => copyValue(item)));

--- a/src/repositories/graph-api-repository.ts
+++ b/src/repositories/graph-api-repository.ts
@@ -105,9 +105,9 @@ export class GraphApiRepository {
     // Returns ids and names for all owned application registrations
     async getApplicationListOwned(filter?: string): Promise<GraphResult<Application[]>> {
         try {
-            const useEventualConsistency = workspace.getConfiguration("applicationregistrations").get("useEventualConsistency") as boolean;
+            const useEventualConsistency = workspace.getConfiguration("applicationRegistrations").get("useEventualConsistency") as boolean;
             if (useEventualConsistency === true) {
-                const maximumApplicationsShown = workspace.getConfiguration("applicationregistrations").get("maximumApplicationsShown") as number;
+                const maximumApplicationsShown = workspace.getConfiguration("applicationRegistrations").get("maximumApplicationsShown") as number;
                 const result: any = await this.client!.api("/me/ownedObjects/$/Microsoft.Graph.Application")
                     .filter(filter === undefined ? "" : filter)
                     .header("ConsistencyLevel", "eventual")
@@ -118,7 +118,7 @@ export class GraphApiRepository {
                     .get();
                 return { success: true, value: result.value };
             } else {
-                const maximumQueryApps = workspace.getConfiguration("applicationregistrations").get("maximumQueryApps") as number;
+                const maximumQueryApps = workspace.getConfiguration("applicationRegistrations").get("maximumQueryApps") as number;
                 const result: any = await this.client!.api("/me/ownedObjects/$/Microsoft.Graph.Application")
                     .top(maximumQueryApps)
                     .select("id,displayName")
@@ -134,9 +134,9 @@ export class GraphApiRepository {
     // Returns ids and names for all application registrations
     async getApplicationListAll(filter?: string): Promise<GraphResult<Application[]>> {
         try {
-            const useEventualConsistency = workspace.getConfiguration("applicationregistrations").get("useEventualConsistency") as boolean;
+            const useEventualConsistency = workspace.getConfiguration("applicationRegistrations").get("useEventualConsistency") as boolean;
             if (useEventualConsistency === true) {
-                const maximumApplicationsShown = workspace.getConfiguration("applicationregistrations").get("maximumApplicationsShown") as number;
+                const maximumApplicationsShown = workspace.getConfiguration("applicationRegistrations").get("maximumApplicationsShown") as number;
                 const result: any = await this.client!.api("/applications/")
                     .filter(filter === undefined ? "" : filter)
                     .header("ConsistencyLevel", "eventual")
@@ -147,7 +147,7 @@ export class GraphApiRepository {
                     .get();
                 return { success: true, value: result.value };
             } else {
-                const maximumQueryApps = workspace.getConfiguration("applicationregistrations").get("maximumQueryApps") as number;
+                const maximumQueryApps = workspace.getConfiguration("applicationRegistrations").get("maximumQueryApps") as number;
                 const result: any = await this.client!.api("/applications/")
                     .top(maximumQueryApps)
                     .select("id,displayName")

--- a/src/services/application.ts
+++ b/src/services/application.ts
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/naming-convention */
-import { AZURE_PORTAL_APP_ROOT, AZURE_PORTAL_APP_PATH, SIGNIN_AUDIENCE_OPTIONS, BASE_ENDPOINT } from "../constants";
+import { AZURE_PORTAL_APP_ROOT, ENTRA_PORTAL_APP_ROOT, AZURE_AND_ENTRA_PORTAL_APP_PATH, SIGNIN_AUDIENCE_OPTIONS, BASE_ENDPOINT } from "../constants";
 import { window, env, Uri, TextDocumentContentProvider, EventEmitter, workspace } from "vscode";
 import { AppRegTreeDataProvider } from "../data/app-reg-tree-data-provider";
 import { AppRegItem } from "../models/app-reg-item";
@@ -293,10 +293,23 @@ export class ApplicationService extends ServiceBase {
         const accountInformation = await this.accountProvider.getAccountInformation();
         let uriText = "";
         if (accountInformation.tenantId){
-            uriText = `${AZURE_PORTAL_APP_ROOT}/${accountInformation.tenantId}${AZURE_PORTAL_APP_PATH}${item.appId}`;
+            uriText = `${AZURE_PORTAL_APP_ROOT}/${accountInformation.tenantId}${AZURE_AND_ENTRA_PORTAL_APP_PATH}${item.appId}`;
         }
         else{
-            uriText = `${AZURE_PORTAL_APP_ROOT}${AZURE_PORTAL_APP_PATH}${item.appId}`;
+            uriText = `${AZURE_PORTAL_APP_ROOT}${AZURE_AND_ENTRA_PORTAL_APP_PATH}${item.appId}`;
+        }
+        env.openExternal(Uri.parse(uriText));
+    }
+
+    // Opens the application registration in the Entra Portal.
+    async openInEntraPortal(item: AppRegItem): Promise<void> {
+        const accountInformation = await this.accountProvider.getAccountInformation();
+        let uriText = "";
+        if (accountInformation.tenantId){
+            uriText = `${ENTRA_PORTAL_APP_ROOT}/${accountInformation.tenantId}${AZURE_AND_ENTRA_PORTAL_APP_PATH}${item.appId}`;
+        }
+        else{
+            uriText = `${ENTRA_PORTAL_APP_ROOT}${AZURE_AND_ENTRA_PORTAL_APP_PATH}${item.appId}`;
         }
         env.openExternal(Uri.parse(uriText));
     }

--- a/src/services/application.ts
+++ b/src/services/application.ts
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/naming-convention */
-import { AZURE_PORTAL_APP_ROOT, ENTRA_PORTAL_APP_ROOT, AZURE_AND_ENTRA_PORTAL_APP_PATH, SIGNIN_AUDIENCE_OPTIONS, BASE_ENDPOINT } from "../constants";
+import { AZURE_PORTAL_ROOT, ENTRA_PORTAL_ROOT, AZURE_AND_ENTRA_PORTAL_APP_PATH, SIGNIN_AUDIENCE_OPTIONS, BASE_ENDPOINT } from "../constants";
 import { window, env, Uri, TextDocumentContentProvider, EventEmitter, workspace } from "vscode";
 import { AppRegTreeDataProvider } from "../data/app-reg-tree-data-provider";
 import { AppRegItem } from "../models/app-reg-item";
@@ -290,26 +290,37 @@ export class ApplicationService extends ServiceBase {
 
     // Opens the application registration in the Azure Portal.
     async openInAzurePortal(item: AppRegItem): Promise<void> {
-        const accountInformation = await this.accountProvider.getAccountInformation();
-        let uriText = "";
-        if (accountInformation.tenantId){
-            uriText = `${AZURE_PORTAL_APP_ROOT}/${accountInformation.tenantId}${AZURE_AND_ENTRA_PORTAL_APP_PATH}${item.appId}`;
-        }
-        else{
-            uriText = `${AZURE_PORTAL_APP_ROOT}${AZURE_AND_ENTRA_PORTAL_APP_PATH}${item.appId}`;
-        }
-        env.openExternal(Uri.parse(uriText));
+        return this.openInPortal(AZURE_PORTAL_ROOT, item);
     }
 
     // Opens the application registration in the Entra Portal.
     async openInEntraPortal(item: AppRegItem): Promise<void> {
-        const accountInformation = await this.accountProvider.getAccountInformation();
-        let uriText = "";
-        if (accountInformation.tenantId){
-            uriText = `${ENTRA_PORTAL_APP_ROOT}/${accountInformation.tenantId}${AZURE_AND_ENTRA_PORTAL_APP_PATH}${item.appId}`;
+        // Determine if using the Entra portal is enabled.
+        const isEntraEnabled = workspace.getConfiguration("applicationRegistrations").get("includeEntraPortal") as boolean;
+
+        if (isEntraEnabled){
+            return this.openInPortal(ENTRA_PORTAL_ROOT, item);
         }
         else{
-            uriText = `${ENTRA_PORTAL_APP_ROOT}${AZURE_AND_ENTRA_PORTAL_APP_PATH}${item.appId}`;
+            throw new Error("Entra Portal operations are not enabled in the workspace settings.");
+        }
+    }
+
+    private async openInPortal(portalRoot: string, item: AppRegItem): Promise<void>{
+        // Determine if "omit tenant ID from portal requests" has been set.
+        const omitTenantIdFromPortalRequests = workspace.getConfiguration("applicationRegistrations").get("omitTenantIdFromPortalRequests") as boolean;
+
+        let uriText = "";
+        if (omitTenantIdFromPortalRequests === false){
+            const accountInformation = await this.accountProvider.getAccountInformation();
+            if (accountInformation.tenantId){
+                uriText = `${portalRoot}/${accountInformation.tenantId}${AZURE_AND_ENTRA_PORTAL_APP_PATH}${item.appId}`;
+            }
+        }
+
+        // Check if uriText has been set to anything meaningful yet. If not, then set it w/o a tenant ID.
+        if (typeof(uriText) === "string" && uriText.trim().length === 0){
+            uriText = `${portalRoot}${AZURE_AND_ENTRA_PORTAL_APP_PATH}${item.appId}`;
         }
         env.openExternal(Uri.parse(uriText));
     }

--- a/src/services/owner.ts
+++ b/src/services/owner.ts
@@ -1,5 +1,5 @@
 import { window, env, Uri } from "vscode";
-import { AZURE_PORTAL_APP_ROOT, AZURE_PORTAL_USER_PATH } from "../constants";
+import { AZURE_PORTAL_APP_ROOT, ENTRA_PORTAL_APP_ROOT, AZURE_AND_ENTRA_PORTAL_USER_PATH } from "../constants";
 import { AppRegTreeDataProvider } from "../data/app-reg-tree-data-provider";
 import { AppRegItem } from "../models/app-reg-item";
 import { ServiceBase } from "./service-base";
@@ -73,10 +73,23 @@ export class OwnerService extends ServiceBase {
         const accountInformation = await this.accountProvider.getAccountInformation();
         let uriText = "";
         if (accountInformation.tenantId){
-            uriText = `${AZURE_PORTAL_APP_ROOT}/${accountInformation.tenantId}${AZURE_PORTAL_USER_PATH}${item.userId}`;
+            uriText = `${AZURE_PORTAL_APP_ROOT}/${accountInformation.tenantId}${AZURE_AND_ENTRA_PORTAL_USER_PATH}${item.userId}`;
         }
         else{
-            uriText = `${AZURE_PORTAL_APP_ROOT}${AZURE_PORTAL_USER_PATH}${item.userId}`;
+            uriText = `${AZURE_PORTAL_APP_ROOT}${AZURE_AND_ENTRA_PORTAL_USER_PATH}${item.userId}`;
+        }
+        env.openExternal(Uri.parse(uriText));
+    }
+
+    // Opens the user in the Entra Portal.
+    async openInEntraPortal(item: AppRegItem): Promise<void> {
+        const accountInformation = await this.accountProvider.getAccountInformation();
+        let uriText = "";
+        if (accountInformation.tenantId){
+            uriText = `${ENTRA_PORTAL_APP_ROOT}/${accountInformation.tenantId}${AZURE_AND_ENTRA_PORTAL_USER_PATH}${item.userId}`;
+        }
+        else{
+            uriText = `${ENTRA_PORTAL_APP_ROOT}${AZURE_AND_ENTRA_PORTAL_USER_PATH}${item.userId}`;
         }
         env.openExternal(Uri.parse(uriText));
     }

--- a/src/types/account-information.ts
+++ b/src/types/account-information.ts
@@ -1,0 +1,36 @@
+// Basic information about the currently signed-in account
+export class AccountInformation {
+    tenantId: string;           // The tenant ID
+    homeTenantId: string;       // The home tenant ID
+    environmentName: string;    // The current cloud type - AzureCloud, AzureChinaCloud, AzureUSGovernment, AzureGermanCloud    
+    
+    subscriptionName: string;   // The subscription name
+    subscriptionId: string;     // The subscription ID
+
+    constructor(tenantId: string = "", homeTenantId: string = "", environmentName: string = "", subscriptionName: string = "", subscriptionId: string = ""){
+        this.tenantId = tenantId;
+        this.homeTenantId = homeTenantId;
+        this.environmentName = environmentName;
+        this.subscriptionName = subscriptionName;
+        this.subscriptionId = subscriptionId;
+    }
+
+    deserialize(jsonTextInput: string): AccountInformation{
+        var data = null;
+        try{
+            data = JSON.parse(jsonTextInput);
+        }
+        catch (e){
+            // There was a problem parsing the JSON text input.
+            console.error(e);
+        }
+        this.tenantId = data?.tenantId ?? "";
+        this.homeTenantId = data?.homeTenantId ?? "";
+        this.environmentName = data?.environmentName ?? "";
+        this.subscriptionName = data?.name ?? "";
+        this.subscriptionId = data?.id ?? "";
+        return this;
+    }
+};
+
+// Note that available cloud types can be found with "az cloud list": https://learn.microsoft.com/cli/azure/manage-clouds-azure-cli#list-available-clouds

--- a/src/utils/authentication.ts
+++ b/src/utils/authentication.ts
@@ -1,13 +1,13 @@
 import { window } from "vscode";
-import { execShellCmd } from "../utils/exec-shell-cmd";
-import { setStatusBarMessage } from "../utils/status-bar";
+import { setStatusBarMessage } from "./status-bar";
 import { errorHandler } from "../error-handler";
 import { AppRegTreeDataProvider } from "../data/app-reg-tree-data-provider";
+import { AccountProvider } from "../data/account-provider";
 
-// Invokes the Azure CLI sign-in command to authenticate the user.
-export const signInToCli = async (treeDataProvider: AppRegTreeDataProvider) => {
+// Authenticate the user.
+export const signInUser = async (treeDataProvider: AppRegTreeDataProvider, accountProvider : AccountProvider) => {
 	await treeDataProvider.render(undefined, "AUTHENTICATING");
-	const status = await authenticate();
+	const status = await authenticate(accountProvider);
 
 	// The user pressed cancel.
 	if (status === undefined) {
@@ -39,9 +39,9 @@ export const signInToCli = async (treeDataProvider: AppRegTreeDataProvider) => {
 	await treeDataProvider.render(setStatusBarMessage("Loading Application Registrations..."), "AUTHENTICATED");
 };
 
-// Invokes the Azure CLI sign-out command to sign the user out.
-export const signOutFromCli = async (treeDataProvider: AppRegTreeDataProvider) => {
-	const status = await execShellCmd("az logout")
+// Uses the AccountProvider instance to sign out the current user.
+export const signOutUser = async (treeDataProvider: AppRegTreeDataProvider, accountProvider : AccountProvider) => {
+	await accountProvider.logoutUser()
 		.then(async () => {
 			await treeDataProvider.render(undefined, "SIGN-IN");
 		})
@@ -50,8 +50,8 @@ export const signOutFromCli = async (treeDataProvider: AppRegTreeDataProvider) =
 		});
 };
 
-// Invokes the Azure CLI sign-in command to authenticate the user.
-const authenticate = async (): Promise<boolean | undefined> => {
+// Uses the AccountProvider instance to authenticate the user.
+const authenticate = async (accountProvider : AccountProvider): Promise<boolean | undefined> => {
 	// Prompt the user for the tenant name or Id.
 	const tenant = await window.showInputBox({
 		placeHolder: "Tenant Name or ID",
@@ -65,20 +65,6 @@ const authenticate = async (): Promise<boolean | undefined> => {
 		return undefined;
 	}
 
-	// Build the command to invoke the Azure CLI sign-in command.
-	let command = "az login";
-	if (tenant.length > 0) {
-		command += ` --tenant ${tenant}`;
-	}
-
-	// Execute the command.
-	const status = await execShellCmd(command)
-		.then(() => {
-			return true;
-		})
-		.catch(() => {
-			return false;
-		});
-
+	const status = await accountProvider.loginUser(tenant);
 	return status;
 };

--- a/tests/suite/application.test.ts
+++ b/tests/suite/application.test.ts
@@ -3,6 +3,7 @@ import { GraphApiRepository } from "../../src/repositories/graph-api-repository"
 import { AppRegTreeDataProvider } from "../../src/data/app-reg-tree-data-provider";
 import { AppRegItem } from "../../src/models/app-reg-item";
 import { ApplicationService } from "../../src/services/application";
+import { AzureCliAccountProvider } from "../../src/data/azure-cli-account-provider"; 
 
 // Create Jest mocks
 jest.mock("vscode");
@@ -17,7 +18,8 @@ describe("Application Service Tests", () => {
     // Create instances of objects used in the tests
     const graphApiRepository = new GraphApiRepository();
     const treeDataProvider = new AppRegTreeDataProvider(graphApiRepository);
-    const applicationService = new ApplicationService(graphApiRepository, treeDataProvider);
+    const accountProvider = new AzureCliAccountProvider();
+    const applicationService = new ApplicationService(graphApiRepository, treeDataProvider, accountProvider);
 
     // Create spy variables
     let triggerCompleteSpy: jest.SpyInstance<any, unknown[], any>;

--- a/tests/suite/organization.test.ts
+++ b/tests/suite/organization.test.ts
@@ -2,6 +2,7 @@ import * as vscode from "vscode";
 import { GraphApiRepository } from "../../src/repositories/graph-api-repository";
 import { AppRegTreeDataProvider } from "../../src/data/app-reg-tree-data-provider";
 import { OrganizationService } from "../../src/services/organization";
+import { AzureCliAccountProvider } from "../../src/data/azure-cli-account-provider";
 
 // Create Jest mocks
 jest.mock("vscode");
@@ -17,7 +18,8 @@ describe("Organization Service Tests", () => {
 	// Create instances of objects used in the tests
 	const graphApiRepository = new GraphApiRepository();
 	const treeDataProvider = new AppRegTreeDataProvider(graphApiRepository);
-	const organizationService = new OrganizationService(graphApiRepository, treeDataProvider);
+	const accountProvider = new AzureCliAccountProvider();
+	const organizationService = new OrganizationService(graphApiRepository, treeDataProvider, accountProvider);
 
 	// Create spies
     let triggerErrorSpy: jest.SpyInstance<any, unknown[], any>;

--- a/tests/suite/owner.test.ts
+++ b/tests/suite/owner.test.ts
@@ -3,6 +3,7 @@ import { GraphApiRepository } from "../../src/repositories/graph-api-repository"
 import { AppRegTreeDataProvider } from "../../src/data/app-reg-tree-data-provider";
 import { AppRegItem } from "../../src/models/app-reg-item";
 import { OwnerService } from "../../src/services/owner";
+import { AzureCliAccountProvider } from "../../src/data/azure-cli-account-provider";
 
 // Create Jest mocks
 jest.mock("vscode");
@@ -17,7 +18,8 @@ describe("Owner Service Tests", () => {
     // Create instances of objects used in the tests
     const graphApiRepository = new GraphApiRepository();
     const treeDataProvider = new AppRegTreeDataProvider(graphApiRepository);
-    const ownerService = new OwnerService(graphApiRepository, treeDataProvider);
+    const accountProvider = new AzureCliAccountProvider();
+    const ownerService = new OwnerService(graphApiRepository, treeDataProvider, accountProvider);
 
     // Create spy variables
     let triggerCompleteSpy: jest.SpyInstance<any, unknown[], any>;


### PR DESCRIPTION
Includes tenant ID in portal request URLs to deal with situations where the tenant opened in VSCode is not the user's default tenant. Can be turned off with a setting. Also added a menu item for using the Entra portal, which can also be turned on/off in a setting (note: setting is binary right now, should this be a 3-way setting to say "show Azure Portal menu, Show Entra Menu, or Show both menus?)

Starts to include consts and current tenant information (beyond tenant ID) to later be able to make decisions about current cloud and switch URLs to the appropriate cloud. 

Renames config settings category from "applicationregistrations" to "applicationRegistrations" so the auto-casing in the VS Code display will split the words correctly. 

Consolidates "az" command line functions to a wrapper class - CLI Account Provider (fronted by AccountProvider interface.) Put this in Data directory - not sure if repository or service would be more correct.